### PR TITLE
Add group headings to output from studierendenwerk canteens

### DIFF
--- a/canteens/studierendenwerk.py
+++ b/canteens/studierendenwerk.py
@@ -98,6 +98,7 @@ def parse_menu(menu_html):
     soup = bs4.BeautifulSoup(menu_html, 'html.parser')
     menu_groups = soup.find_all('div', class_='splGroupWrapper')
     for group in menu_groups:
+        group_lines = []
         menu_items = group.find_all('div', class_='splMeal')
         for item in menu_items:
             veggie = item.find_all('img', class_='splIcon')
@@ -115,14 +116,13 @@ def parse_menu(menu_html):
             price = item.find('div', class_='text-right').text.strip()
             price_exp = re.compile(r'€ (\d,\d+).*$')
             price = price_exp.sub('*\g<1>€*', price)
-            text = '%s%s %s: %s\n' % (text, annotation, title, price)
-    if text.strip() == '':
-        return ''
-    else:
-        lines = text.split('\n')
-        lines.sort()
-        text = '\n'.join(lines)
-        return '*Speiseplan*%s' % text
+            group_lines.append('%s %s: %s' % (annotation, title, price))
+
+        if len(group_lines) > 0:
+            group_heading = group.find('div').find('div').text.strip()
+            group_text = '\n'.join(sorted(group_lines)).strip()
+            text += '\n*%s*\n%s\n' % (group_heading, group_text)
+    return text.strip()
 
 
 def parse_notes(notes_html):

--- a/tests/studierendenwerk_sample.html
+++ b/tests/studierendenwerk_sample.html
@@ -1,0 +1,294 @@
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 1</div>
+    </div>
+    <div class="row splMeal" lang="6,7,13,21a,23,27,30">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gelb_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/38.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 1 Item 1</span>
+            <div class="kennz ptr toolt">
+                (6, 7, 13, 21a, 23, 27, 30)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>6</td>
+                        <td>konserviert</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>7</td>
+                        <td>Antioxidationsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>13</td>
+                        <td>Süßungsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>21a</td>
+                        <td>Weizen</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>23</td>
+                        <td>Eier</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>27</td>
+                        <td>Sellerie</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>30</td>
+                        <td>Milch und Milchprodukte (inkl. Laktose)</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 1,75/1,95/2,10
+        </div>
+    </div>
+</div>
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 2</div>
+    </div>
+    <div class="row splMeal" lang="13,27">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 2 Item 1</span>
+            <div class="kennz ptr toolt">
+                (13, 27)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>13</td>
+                        <td>Süßungsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>27</td>
+                        <td>Sellerie</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 1,75/3,50/3,85
+        </div>
+    </div>
+    <div class="row splMeal" lang="13,27">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 2 Item 2</span>
+            <div class="kennz ptr toolt">
+                (13, 27)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>13</td>
+                        <td>Süßungsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>27</td>
+                        <td>Sellerie</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,65/1,30/1,45
+        </div>
+    </div>
+</div>
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 3</div>
+    </div>
+    <div class="row splMeal" lang="7,28">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 3 Item 1</span>
+            <div class="kennz ptr toolt">
+                (7, 28)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>7</td>
+                        <td>Antioxidationsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>28</td>
+                        <td>Soja</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,60/1,20/1,30
+        </div>
+    </div>
+</div>
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 4</div>
+    </div>
+    <div class="row splMeal" lang="21a">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/43.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 4 Item 1</span>
+            <div class="kennz ptr toolt">
+                (21a)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>21a</td>
+                        <td>Weizen</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 1,90/3,80/4,20
+        </div>
+    </div>
+    <div class="row splMeal" lang="7,8,21a,23,27,30,34,36">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_rot_70x65.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 4 Item 2</span>
+            <div class="kennz ptr toolt">
+                (7, 8, 21a, 23, 27, 30, 34, 36)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>7</td>
+                        <td>Antioxidationsmittel</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>8</td>
+                        <td>Farbstoff</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>21a</td>
+                        <td>Weizen</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>23</td>
+                        <td>Eier</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>27</td>
+                        <td>Sellerie</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>30</td>
+                        <td>Milch und Milchprodukte (inkl. Laktose)</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>34</td>
+                        <td>Weichtiere</td>
+                    </tr>
+                    <tr>
+                        <td class='text-right'>36</td>
+                        <td>Hefe</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 1,75/3,50/3,85
+        </div>
+    </div>
+    <div class="row splMeal" lang="">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gelb_70x65.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 4 Item 3</span>
+            <div class="kennz ptr toolt">
+
+                <table class='table-condensed tooltip_content'></table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 1,35/2,70/2,95
+        </div>
+    </div>
+</div>
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 5</div>
+    </div>
+    <div class="row splMeal" lang="">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 5 Item 1</span>
+            <div class="kennz ptr toolt">
+
+                <table class='table-condensed tooltip_content'></table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,60/1,20/1,30
+        </div>
+    </div>
+    <div class="row splMeal" lang="">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 5 Item 2</span>
+            <div class="kennz ptr toolt">
+
+                <table class='table-condensed tooltip_content'></table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,60/1,20/1,30
+        </div>
+    </div>
+    <div class="row splMeal" lang="">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gelb_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/15.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 5 Item 3</span>
+            <div class="kennz ptr toolt">
+
+                <table class='table-condensed tooltip_content'></table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,60/1,20/1,30
+        </div>
+    </div>
+</div>
+<div class="container-fluid splGroupWrapper">
+    <div class="row">
+        <div class="col-md-12 splGroup">Group 6</div>
+    </div>
+    <div class="row splMeal" lang="30">
+        <div class="col-xs-12 col-md-3">
+            <img src='/vendor/infomax/mensen/icons/ampel_gruen_70x65.png' class='splIcon'><img src='/vendor/infomax/mensen/icons/1.png' class='splIcon'>
+        </div>
+        <div class="col-xs-6 col-md-6">
+            <span class="bold">Group 6 Item 1</span>
+            <div class="kennz ptr toolt">
+                (30)
+                <table class='table-condensed tooltip_content'>
+                    <tr>
+                        <td class='text-right'>30</td>
+                        <td>Milch und Milchprodukte (inkl. Laktose)</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="col-xs-6 col-md-3 text-right">
+            &euro; 0,65/1,30/1,45
+        </div>
+    </div>
+</div>

--- a/tests/test_studierendenwerk.py
+++ b/tests/test_studierendenwerk.py
@@ -1,12 +1,43 @@
+import os.path
 import pytest
+from emoji import emojize
 from flaky import flaky
 
 import datetime
 
 from canteens import studierendenwerk
 
+
+@pytest.fixture
+def studierendenwerk_sample() -> str:
+    path = os.path.join(os.path.dirname(__file__), 'studierendenwerk_sample.html')
+    with open(path) as file:
+        return file.read()
+
+
 @flaky
 def test_download_menu__with_live_site():
     date = datetime.datetime.today().strftime(studierendenwerk.DATE_FORMAT_API)
     html = studierendenwerk.download_menu(538, date)
     assert 'Milch und Milchprodukte' in html
+
+
+def test_parse_sample_menu(studierendenwerk_sample: str):
+    parsed = studierendenwerk.parse_menu(studierendenwerk_sample)
+    assert parsed == emojize('*Group 1*\n'
+                             ':fish: Group 1 Item 1: *1,75€*\n'
+                             '\n*Group 2*\n'
+                             ':seedling: Group 2 Item 1: *1,75€*\n'
+                             ':seedling: Group 2 Item 2: *0,65€*\n'
+                             '\n*Group 3*\n'
+                             ':seedling: Group 3 Item 1: *0,60€*\n'
+                             '\n*Group 4*\n'
+                             ':seedling: Group 4 Item 1: *1,90€*\n'
+                             ':poultry_leg: Group 4 Item 2: *1,75€*\n'
+                             ':poultry_leg: Group 4 Item 3: *1,35€*\n'
+                             '\n*Group 5*\n'
+                             ':seedling: Group 5 Item 1: *0,60€*\n'
+                             ':seedling: Group 5 Item 2: *0,60€*\n'
+                             ':seedling: Group 5 Item 3: *0,60€*\n'
+                             '\n*Group 6*\n'
+                             ':ear_of_corn: Group 6 Item 1: *0,65€*')


### PR DESCRIPTION
Currently, studierendenwerk dishes are all printed together, without the group headings under which they appear on the website.

This is imperfect, as often, you need to choose a main dish as well as a side. This PR seeks to make this easier by distinguishing between the different dish groups.

With these changes, output will look like the following:
![grafik](https://user-images.githubusercontent.com/29020266/52296059-ba9ccd80-297d-11e9-83ef-3c32245c00bf.png)


Additionally, this PR adds a minor test of the studierendenwerk parser by having it parse a known sample html file, pulled from the website.

Merry Christmas o/,
Also Max

**Edit:** Updated screenshot after changes